### PR TITLE
Missing HEAD method usage flag reset between two requests.

### DIFF
--- a/src/vtc_http.c
+++ b/src/vtc_http.c
@@ -1275,6 +1275,7 @@ cmd_http_txreq(CMD_ARGS)
 
 	VSB_clear(hp->vsb);
 
+	hp->head_method = 0;
 	for (; *av != NULL; av++) {
 		if (!strcmp(*av, "-url")) {
 			url = av[1];


### PR DESCRIPTION
If an HTTP client request with a method different from HEAD followed
another one with HEAD method, the former was still flagged as being
using the HEAD method because of a missing HEAD method usage flag
reset before building an HTTP client request.