### PR TITLE
Reinitialize cyclic barrier only once per cycle

### DIFF
--- a/src/vtc_barrier.c
+++ b/src/vtc_barrier.c
@@ -274,15 +274,14 @@ barrier_cond_sync(struct barrier *b, struct vtclog *vl)
 
 	if (++b->waiters == b->expected) {
 		vtc_log(vl, 4, "Barrier(%s) wake %u", b->name, b->expected);
+                if (b->cyclic)
+                    b->waiters = 0;
 		AZ(pthread_cond_broadcast(&b->cond));
 	} else {
 		vtc_log(vl, 4, "Barrier(%s) wait %u of %u",
 		    b->name, b->waiters, b->expected);
 		AZ(pthread_cond_wait(&b->cond, &b->mtx));
 	}
-
-	if (b->cyclic)
-		b->waiters = 0;
 }
 
 static void


### PR DESCRIPTION
It was done for all threads syncing on a barrier. The one reaching the limit but
also all waiting threads. So it could be reset by a thread while others have
already started another round, leading to an deadlock (because some increments
will be lost then).

Now, cyclic barrier is reset for a new round by the thread reaching the limit
and only this one.