### PR TITLE
vtc_haproxy: enable mcli with its own flag

### DIFF
--- a/a00020.vtc
+++ b/a00020.vtc
@@ -9,7 +9,7 @@ feature cmd {haproxy --version 2>&1 | grep -q 'HA-Proxy version'}
 server s1 {
 } -start
 
-haproxy h1 -W -conf {
+haproxy h1 -W -S -conf {
     global
 	nbproc 4
     defaults


### PR DESCRIPTION
Support for the master cli in worker mode was added with commit 86e65f1
using the same flag as worker mode (-W). This is a problem with haproxy
1.8 because it has worker mode but no mcli. This PR adds -S to enable
mcli for haproxy in a vtc, and updates a00020.vtc accordingly.