### PR TITLE
Avoid VSB_printf for static strings

### DIFF
--- a/lib/vsb.c
+++ b/lib/vsb.c
@@ -525,9 +525,9 @@ VSB_quote_pfx(struct vsb *s, const char *pfx, const void *v, int len, int how)
 		for (w = u; w < u + len; w++)
 			if (*w != 0x00)
 				break;
-		VSB_printf(s, "0x");
+		VSB_cat(s, "0x");
 		if (w == u + len && len > 4) {
-			VSB_printf(s, "0...0");
+			VSB_cat(s, "0...0");
 		} else {
 			for (w = u; w < u + len; w++)
 				VSB_printf(s, "%02x", *w);

--- a/lib/vsub.c
+++ b/lib/vsub.c
@@ -178,8 +178,8 @@ VSUB_run(struct vsb *sb, vsub_func_f *func, void *priv, const char *name,
 			VSB_printf(sb, ", signal %d", WTERMSIG(status));
 		}
 		if (WCOREDUMP(status))
-			VSB_printf(sb, ", core dumped");
-		VSB_printf(sb, "\n");
+			VSB_cat(sb, ", core dumped");
+		VSB_cat(sb, "\n");
 		assert(rv != -1);
 		return (rv);
 	}

--- a/src/vtc_haproxy.c
+++ b/src/vtc_haproxy.c
@@ -682,14 +682,14 @@ haproxy_start(struct haproxy *h)
 
 	VSB_printf(vsb, "exec \"%s\"", h->filename);
 	if (h->opt_check_mode)
-		VSB_printf(vsb, " -c");
+		VSB_cat(vsb, " -c");
 	else if (h->opt_daemon)
-		VSB_printf(vsb, " -D");
+		VSB_cat(vsb, " -D");
 	else
-		VSB_printf(vsb, " -d");
+		VSB_cat(vsb, " -d");
 
 	if (h->opt_worker) {
-		VSB_printf(vsb, " -W");
+		VSB_cat(vsb, " -W");
 		if (h->opt_mcli) {
 			int sock;
 			sock = haproxy_create_mcli(h);
@@ -899,7 +899,7 @@ haproxy_store_conf(struct haproxy *h, const char *cfg, int auto_be)
 
 	VSB_printf(vsb, "    global\n\tstats socket \"%s\" "
 		   "level admin mode 600\n", h->cli_fn);
-	VSB_printf(vsb, "    stats socket \"fd@${cli}\" level admin\n");
+	VSB_cat(vsb, "    stats socket \"fd@${cli}\" level admin\n");
 	AZ(VSB_cat(vsb, cfg));
 
 	if (auto_be)

--- a/src/vtc_log.c
+++ b/src/vtc_log.c
@@ -257,7 +257,7 @@ vtc_hexdump(struct vtclog *vl, int lvl, const char *pfx,
 	else {
 		for (l = 0; l < len; l++, ss++) {
 			if (l > 512) {
-				VSB_printf(vl->vsb, "...");
+				VSB_cat(vl->vsb, "...");
 				break;
 			}
 			if (nl) {
@@ -266,13 +266,13 @@ vtc_hexdump(struct vtclog *vl, int lvl, const char *pfx,
 			}
 			VSB_printf(vl->vsb, " %02x", *ss);
 			if ((l & 0xf) == 0xf) {
-				VSB_printf(vl->vsb, "\n");
+				VSB_cat(vl->vsb, "\n");
 				nl = 1;
 			}
 		}
 	}
 	if (!nl)
-		VSB_printf(vl->vsb, "\n");
+		VSB_cat(vl->vsb, "\n");
 	REL_VL(vl);
 	if (lvl == 0)
 		vtc_logfail();

--- a/src/vtc_main.c
+++ b/src/vtc_main.c
@@ -509,7 +509,7 @@ i_mode(void)
 	/*
 	 * Build $PATH which can find all programs in the build tree
 	 */
-	VSB_printf(vsb, "PATH=");
+	VSB_cat(vsb, "PATH=");
 	sep = "";
 #define VTC_PROG(l)							\
 	do {								\
@@ -734,7 +734,7 @@ main(int argc, char * const *argv)
 			ntest = strtoul(optarg, NULL, 0);
 			break;
 		case 'p':
-			VSB_printf(params_vsb, " -p ");
+			VSB_cat(params_vsb, " -p ");
 			VSB_quote(params_vsb, optarg, -1, 0);
 			break;
 		case 'q':

--- a/src/vtc_proxy.c
+++ b/src/vtc_proxy.c
@@ -100,9 +100,9 @@ vtc_send_proxy(int fd, int version, const struct suckaddr *sac,
 	if (version == 1) {
 		VSB_bcat(vsb, vpx1_sig, sizeof(vpx1_sig));
 		if (proto == PF_INET6)
-			VSB_printf(vsb, " TCP6 ");
+			VSB_cat(vsb, " TCP6 ");
 		else if (proto == PF_INET)
-			VSB_printf(vsb, " TCP4 ");
+			VSB_cat(vsb, " TCP4 ");
 		VTCP_name(sac, hc, sizeof(hc), pc, sizeof(pc));
 		VTCP_name(sas, hs, sizeof(hs), ps, sizeof(ps));
 		VSB_printf(vsb, "%s %s %s %s\r\n", hc, hs, pc, ps);

--- a/src/vtc_varnish.c
+++ b/src/vtc_varnish.c
@@ -407,7 +407,7 @@ varnish_launch(struct varnish *v)
 	vtc_log(v->vl, 2, "Launch");
 	vsb = VSB_new_auto();
 	AN(vsb);
-	VSB_printf(vsb, "cd ${pwd} &&");
+	VSB_cat(vsb, "cd ${pwd} &&");
 	VSB_printf(vsb, " exec varnishd %s -d -n %s",
 	    v->jail, v->workdir);
 	VSB_cat(vsb, VSB_data(params_vsb));
@@ -418,13 +418,13 @@ varnish_launch(struct varnish *v)
 		VSB_cat(vsb, " -p debug=+vmod_so_keep");
 		VSB_cat(vsb, " -p debug=+vsm_keep");
 	}
-	VSB_printf(vsb, " -l 2m");
-	VSB_printf(vsb, " -p auto_restart=off");
-	VSB_printf(vsb, " -p syslog_cli_traffic=off");
-	VSB_printf(vsb, " -p sigsegv_handler=on");
-	VSB_printf(vsb, " -p thread_pool_min=10");
-	VSB_printf(vsb, " -p debug=+vtc_mode");
-	VSB_printf(vsb, " -p vsl_mask=+Debug");
+	VSB_cat(vsb, " -l 2m");
+	VSB_cat(vsb, " -p auto_restart=off");
+	VSB_cat(vsb, " -p syslog_cli_traffic=off");
+	VSB_cat(vsb, " -p sigsegv_handler=on");
+	VSB_cat(vsb, " -p thread_pool_min=10");
+	VSB_cat(vsb, " -p debug=+vtc_mode");
+	VSB_cat(vsb, " -p vsl_mask=+Debug");
 	if (!v->has_a_arg) {
 		VSB_printf(vsb, " -a '%s'", "127.0.0.1:0");
 		if (v->proto != NULL)


### PR DESCRIPTION
Done with the following semantic patch for Coccinelle:

    @@
    expression vsb, fmt;
    @@

    - VSB_printf(vsb, fmt);
    + VSB_cat(vsb, fmt);

This patch is available in the Varnish source tree.