### PR TITLE
do not use explicit buffer size at getcwd func

### DIFF
--- a/src/vtc_main.c
+++ b/src/vtc_main.c
@@ -698,7 +698,7 @@ main(int argc, char * const *argv)
 	else
 		tmppath = strdup("/tmp");
 
-	cwd = getcwd(NULL, PATH_MAX);
+	cwd = getcwd(0, 0);
 	extmacro_def("pwd", "%s", cwd);
 
 	vmod_path = NULL;


### PR DESCRIPTION
I can't compile `vtest` on my Arch linux with

- kernel: 5.8.8-arch1-1
- glibc: 2.32
- gcc: 10.2.0

I got this error:

```
$ make vtest
awk -f src/gensequences src/sequences > src/teken_state.h
trying python3
cc \
	-O2 -s -Wall -Werror \
	-o vtest \
	-Isrc -Ilib -I/usr/local/include -pthread \
	src/*.c lib/*.c \
	-L/usr/local/lib -lm -lpcre -lz
src/vtc_main.c: In function ‘main’:
src/vtc_main.c:701:8: error: argument 1 is null but the corresponding size argument 2 value is 4096 [-Werror=nonnull]
  701 |  cwd = getcwd(NULL, PATH_MAX);
      |        ^~~~~~~~~~~~~~~~~~~~~~
In file included from src/vtc_main.c:43:
/usr/include/unistd.h:520:14: note: in a call to function ‘getcwd’ declared with attribute ‘write_only (1, 2)’
  520 | extern char *getcwd (char *__buf, size_t __size) __THROW __wur
      |              ^~~~~~
cc1: all warnings being treated as errors
make: *** [Makefile:37: vtest] Error 1
```

so I applied the fix that's suggested in https://gcc.gnu.org/bugzilla/show_bug.cgi?format=multiple&id=96832
