### PR TITLE
vtc_haproxy: VTCP_listen_on 127.0.0.1 instead of localhost

### DIFF
--- a/src/vtc_haproxy.c
+++ b/src/vtc_haproxy.c
@@ -520,7 +520,7 @@ haproxy_create_mcli(struct haproxy *h)
 	const char *err;
 	char buf[128], addr[128], port[128];
 
-	sock = VTCP_listen_on("localhost:0", NULL, 100, &err);
+	sock = VTCP_listen_on("127.0.0.1:0", NULL, 100, &err);
 	if (err != NULL)
 		vtc_fatal(h->vl,
 			  "Create listen socket failed: %s", err);
@@ -591,7 +591,7 @@ haproxy_new(const char *name)
 	 * May be useful to simulate an unreachable server.
 	 */
 	bprintf(h->closed_sock, "%s_closed", h->name);
-	closed_sock = VTCP_listen_on("localhost:0", NULL, 100, &err);
+	closed_sock = VTCP_listen_on("127.0.0.1:0", NULL, 100, &err);
 	if (err != NULL)
 		vtc_fatal(h->vl,
 			"Create listen socket failed: %s", err);
@@ -847,7 +847,7 @@ haproxy_build_backends(struct haproxy *h, const char *vsb_data)
 			break;
 
 		*q++ = '\0';
-		sock = VTCP_listen_on("localhost:0", NULL, 100, &err);
+		sock = VTCP_listen_on("127.0.0.1:0", NULL, 100, &err);
 		if (err != NULL)
 			vtc_fatal(h->vl,
 			    "Create listen socket failed: %s", err);


### PR DESCRIPTION
Always bind vtc_haproxy with 127.0.0.1 instead of binding on ::1 or
127.0.0.1 depending on the environment.

This is related to bug https://github.com/haproxy/haproxy/issues/937
here the ipv6 and ipv4 are randomly mixed which can't work with socks4.