### PR TITLE
vtc_haproxy: support passing extra arguments via HAPROXY_ARGS

### DIFF
--- a/src/vtc_haproxy.c
+++ b/src/vtc_haproxy.c
@@ -48,6 +48,7 @@
 #include "vtim.h"
 
 #define HAPROXY_PROGRAM_ENV_VAR	"HAPROXY_PROGRAM"
+#define HAPROXY_ARGS_ENV_VAR	"HAPROXY_ARGS"
 #define HAPROXY_OPT_WORKER	"-W"
 #define HAPROXY_OPT_MCLI	"-S"
 #define HAPROXY_OPT_DAEMON	"-D"
@@ -558,12 +559,18 @@ haproxy_new(const char *name)
 	int closed_sock;
 	char addr[128], port[128];
 	const char *err;
+	const char *env_args;
 
 	ALLOC_OBJ(h, HAPROXY_MAGIC);
 	AN(h);
 	REPLACE(h->name, name);
 
 	h->args = VSB_new_auto();
+	env_args = getenv(HAPROXY_ARGS_ENV_VAR);
+	if (env_args) {
+		VSB_cat(h->args, env_args);
+		VSB_cat(h->args, " ");
+	}
 
 	h->vl = vtc_logopen("%s", name);
 	vtc_log_set_cmd(h->vl, haproxy_cli_cmds);


### PR DESCRIPTION
We're missing the ability to easily pass some extra debugging options,
typically memory poisonning or memory limitations, while executing tests.
Let's add the consideration for the HAPROXY_ARGS environment variable, to
optionally prepend a series of arguments.