### PR TITLE
Fix this compilation issue when building with GCC:

### DIFF
--- a/lib/vtcp.c
+++ b/lib/vtcp.c
@@ -58,6 +58,14 @@
 #include "vtcp.h"
 #include "vtim.h"
 
+#ifndef __SANITIZE_ADDRESS__
+#ifdef __clang__
+#if __has_feature(address_sanitizer)
+#define __SANITIZE_ADDRESS__
+#endif
+#endif
+#endif
+
 /*--------------------------------------------------------------------*/
 static void
 vtcp_sa_to_ascii(const void *sa, socklen_t l, char *abuf, unsigned alen,
@@ -629,7 +637,7 @@ VTCP_Check(ssize_t a)
 	if (errno == EINVAL)
 		return (1);
 #endif
-#if (defined(__SANITIZER) || __has_feature(address_sanitizer))
+#ifdef __SANITIZE_ADDRESS__
 	if (errno == EINTR)
 		return (1);
 #endif


### PR DESCRIPTION
    lib/vtcp.c: In function ‘VTCP_Check’:
    lib/vtcp.c:632:43: error: missing binary operator before token "("
    #if (defined(__SANITIZER) || __has_feature(address_sanitizer))
                                              ^