### PR TITLE
Don't expect payload on 304-Not-Modified response

### DIFF
--- a/src/vtc_http.c
+++ b/src/vtc_http.c
@@ -711,7 +711,7 @@ cmd_http_rxresp(CMD_ARGS)
 		return;
 	if (!hp->resp[0] || !hp->resp[1])
 		return;
-	if (hp->head_method)
+	if (hp->head_method || !strcmp(hp->resp[1], "304"))
 		return;
 	if (!strcmp(hp->resp[1], "200"))
 		http_swallow_body(hp, hp->resp, 1, 0);


### PR DESCRIPTION
304-Not-Modified responses must not contain content or trailers and are terminated at the end of the header section. So don't try to read any message payload.

This patch fixes a bug when a 304 response contains a Content-Length or a Transfer-Encoding header. In this case, and without this patch, VTest tries to honor these headers when found and waits for a body.