### PR TITLE
Add include command

### DIFF
--- a/src/cmds.h
+++ b/src/cmds.h
@@ -37,6 +37,7 @@
 CMD_GLOBAL(barrier)
 CMD_GLOBAL(delay)
 CMD_GLOBAL(shell)
+CMD_GLOBAL(include)
 #undef CMD_GLOBAL
 
 #ifndef CMD_TOP

--- a/src/vtc_misc.c
+++ b/src/vtc_misc.c
@@ -52,6 +52,7 @@
 #include "vtcp.h"
 #include "vss.h"
 #include "vtim.h"
+#include "vfil.h"
 
 /* SECTION: vtest vtest
  *
@@ -344,6 +345,40 @@ cmd_delay(CMD_ARGS)
 		vtc_fatal(vl, "Syntax error in number (%s)", av[1]);
 	vtc_log(vl, 3, "delaying %g second(s)", f);
 	VTIM_sleep(f);
+}
+
+/* SECTION: include include
+ *
+ * Executes a vtc fragment::
+ *
+ *         include FILE [...]
+ *
+ * Open a file and execute it as a VTC fragment. This command is available
+ * everywhere commands are given.
+ *
+ */
+void
+cmd_include(CMD_ARGS)
+{
+	char *spec;
+	unsigned i;
+
+	if (av == NULL)
+		return;
+
+	if (av[1] == NULL)
+		vtc_fatal(vl, "CMD include: At least 1 argument required");
+
+	for (i = 1; av[i] != NULL; i++) {
+		spec = VFIL_readfile(NULL, av[i], NULL);
+		if (spec == NULL)
+			vtc_fatal(vl, "CMD include: Unable to read file '%s' "
+			    "(%s)", av[i], strerror(errno));
+		vtc_log(vl, 2, "Begin include '%s'", av[i]);
+		parse_string(vl, priv, spec);
+		vtc_log(vl, 2, "End include '%s'", av[i]);
+		free(spec);
+	}
 }
 
 /**********************************************************************

--- a/tests/a00021.vtc
+++ b/tests/a00021.vtc
@@ -1,0 +1,28 @@
+varnishtest "Test VTC includes"
+
+shell {
+	cat >${tmpdir}/f1 <<-EOF
+	rxreq
+	EOF
+}
+
+shell {
+	cat >${tmpdir}/f2 <<-EOF
+	txresp
+	EOF
+}
+
+shell {
+	cat >${tmpdir}/f3 <<-EOF
+	server s1 {
+		include "${tmpdir}/f1" "${tmpdir}/f2"
+	} -start
+	EOF
+}
+
+include "${tmpdir}/f3"
+
+client c1 -connect "${s1_sock}" {
+	txreq
+	rxresp
+} -run


### PR DESCRIPTION
The contents of a file included by this command are executed as-is. The command is global, which means that the include command can be used inside HTTP specs as the test case shows. We require at least one argument, and subsequent file path arguments are parsed in order.

This command can be used to build more complex VTCs, as well as reducing repetitiveness. We make no attempts to avoid circular includes.