### PR TITLE
Minor build updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,11 +66,11 @@ varnishtest:	${DEPS}
 src/vtc_h2_dectbl.h:	src/huffman_gen.py src/tbl/vhp_huffman.h
 	@( echo trying python3 && \
 	${PYTHON3} src/huffman_gen.py src/tbl/vhp_huffman.h > $@ ) || \
-	( echo trying python2 instead && \
+	( rm -f $@; echo trying python2 instead && \
 	${PYTHON2} src/huffman_gen.py src/tbl/vhp_huffman.h > $@ ) || \
-	( echo trying python instead && \
+	( rm -f $@; echo trying python instead && \
 	${PYTHON} src/huffman_gen.py src/tbl/vhp_huffman.h > $@ ) || \
-	( echo failed && exit 1 )
+	( rm -f $@; echo failed && exit 1 )
 
 #######################################################################
 

--- a/Makefile
+++ b/Makefile
@@ -11,14 +11,20 @@ AWK	?=	awk
 SRCS=	src/*.c \
 	lib/*.c
 
-DEPS=	${SRCS} \
-	lib/*.h \
+OBJS=	src/*.o \
+	lib/*.o
+
+DEPS=	lib/*.h \
 	src/*.h \
 	src/tbl/*.h \
 	src/teken_state.h \
 	src/vtc_h2_dectbl.h
 
-FLAGS=	-O2 -s -Wall -Werror
+FLAGS=	-O2 -Wall -Werror
+
+CFLAGS=  ${FLAGS}
+LDFLAGS= ${FLAGS} -s
+DEFINES=
 
 INCS=	-Isrc \
 	-Ilib \
@@ -33,12 +39,17 @@ LIBS=	-L/usr/local/lib \
 #######################################################################
 # If you want to build vtest without varnish support, use this part:
 
-vtest: ${DEPS}
+vtest: ${DEPS} ${SRCS}
+	${MAKE} \
+		${MAKEFLAGS} \
+		 DEFINES= \
+		 `for s in $(SRCS); do echo $${s%.c}.o;done`
+
 	${CC} \
-		${FLAGS} \
+		${LDFLAGS} \
 		-o vtest \
 		${INCS} \
-		${SRCS} \
+		${OBJS} \
 		${LIBS}
 
 test: vtest
@@ -47,19 +58,31 @@ test: vtest
 #######################################################################
 # ... other point to varnish source tree and use this part:
 
-varnishtest:	${DEPS}
+varnishtest:	${DEPS} ${SRCS}
+	${MAKE} \
+		${MAKEFLAGS} \
+		 DEFINES="-DVTEST_WITH_VTC_VARNISH -DVTEST_WITH_VTC_LOGEXPECT" \
+		 `for s in $(SRCS); do echo $${s%.c}.o;done`
+
 	${CC} \
-		${FLAGS} \
+		${LDFLAGS} \
 		-o varnishtest \
-		-DVTEST_WITH_VTC_VARNISH \
-		-DVTEST_WITH_VTC_LOGEXPECT \
-		${INCS} \
-		-I${VARNISH_SRC}/include \
-		${SRCS} \
+		${OBJS} \
 		${LIBS} \
 		-L${VARNISH_SRC}/lib/libvarnishapi/.libs \
 		-Wl,--rpath,${VARNISH_SRC}/lib/libvarnishapi/.libs \
 		-lvarnishapi
+
+#######################################################################
+# Implicit rule used in a sub-process by the rules above, and makes use
+# of ${DEFINES} for extra arguments :
+.c.o:
+	${CC} \
+		${CFLAGS} \
+		${DEFINES} \
+		${INCS} \
+		-I${VARNISH_SRC}/include \
+		-o $@ -c $<
 
 #######################################################################
 
@@ -83,3 +106,4 @@ clean:
 	rm -f vtest varnishtest
 	rm -f src/teken_state.h
 	rm -f src/vtc_h2_dectbl.h
+	rm -f ${OBJS}


### PR DESCRIPTION
Hi Poul-Henning!

I've addressed a small issue in the makefile in case of error with the python script, it didn't automatically remove the generated files, so that a second build attempt would not try to rebuild them and would cause the failure later in the build process.

Additionally, I've added support for individual file builds, which implicitly also enables parallel builds on multi-core machines. Indeed, on some machines the build is super slow and when you discover after 4 minutes that it fails due to missing pcre2.h, that's quite annoying! I made sure to preserve BSD make compatibility. For this it issues a make sub-process to build all files so that we continue not to require explicit file name enumeration (since I noticed it was apparently intentional for ease of maintenance).

I tested this on linux, freebsd (gmake), openbsd (make) and all worked fine (and allowed me to complete the openbsd setup much faster, that was the super slow machine). Please note, I've only tested the vtest target. The varnishtest one ought to be OK since the change is essentially mechanical, but I wouldn't mind if you double-check it form one of your checked out varnish sources.

Maybe one day I'll find the courage to rewrite the hpack generator in a more portable language than python so that we don't have to install it just for this (especially on small machines). ksh/bash/awk/C come to mind here.

Thanks!