### PR TITLE
Don't explicitly pass makeflags into sub-make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,6 @@ LIBS=	-L/usr/local/lib \
 
 vtest: ${DEPS} ${SRCS}
 	${MAKE} \
-		${MAKEFLAGS} \
 		 DEFINES= \
 		 `for s in $(SRCS); do echo $${s%.c}.o;done`
 
@@ -60,7 +59,6 @@ test: vtest
 
 varnishtest:	${DEPS} ${SRCS}
 	${MAKE} \
-		${MAKEFLAGS} \
 		 DEFINES="-DVTEST_WITH_VTC_VARNISH -DVTEST_WITH_VTC_LOGEXPECT" \
 		 `for s in $(SRCS); do echo $${s%.c}.o;done`
 


### PR DESCRIPTION
According to [Communicating Options to a Sub-make](https://porthos.tecnico.ulisboa.pt/docs/make/make_toc.html#TOC53) 
>Flags such as `-s' and `-k' are passed automatically to the sub-make through the variable MAKEFLAGS. This variable is set up automatically by make to contain the flag letters that make received. Thus, if you do `make -ks' then MAKEFLAGS gets the value `ks'. As a consequence, every sub-make gets a value for MAKEFLAGS in its environment. The options `-C', `-f', `-o', and `-W' are not put into MAKEFLAGS; these options are not passed down.

So an explicit passing through of MAKEFLAGS to sub-make is not needed.

# Alternatives

An alternative approach to maintaining compatibility with old 'make's may be  `$(MAKE) $(MFLAGS)`. Or `$(MAKE) MAKEFLAGS=${MAKEFLAGS}`, which will pass through all the flags, including the ones that should be omitted. But not `${MAKE} ${MAKEFLAGS}`  which leads to a malformed command.


Closes #36